### PR TITLE
Task/seperate into solutions

### DIFF
--- a/src/BuildTimeHistory.sln
+++ b/src/BuildTimeHistory.sln
@@ -11,6 +11,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\README.md = ..\README.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SolutionBuildTimeHistory.Test", "SolutionBuildTimeHistory.Test\SolutionBuildTimeHistory.Test.csproj", "{0189AE3B-4B8E-4DD9-87E5-3F2FF301F7B0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,18 @@ Global
 		{EBB11B94-8ED3-4CC5-8B46-B3A6B6EA2E6E}.Release|arm64.Build.0 = Release|arm64
 		{EBB11B94-8ED3-4CC5-8B46-B3A6B6EA2E6E}.Release|x86.ActiveCfg = Release|x86
 		{EBB11B94-8ED3-4CC5-8B46-B3A6B6EA2E6E}.Release|x86.Build.0 = Release|x86
+		{0189AE3B-4B8E-4DD9-87E5-3F2FF301F7B0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0189AE3B-4B8E-4DD9-87E5-3F2FF301F7B0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0189AE3B-4B8E-4DD9-87E5-3F2FF301F7B0}.Debug|arm64.ActiveCfg = Debug|Any CPU
+		{0189AE3B-4B8E-4DD9-87E5-3F2FF301F7B0}.Debug|arm64.Build.0 = Debug|Any CPU
+		{0189AE3B-4B8E-4DD9-87E5-3F2FF301F7B0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0189AE3B-4B8E-4DD9-87E5-3F2FF301F7B0}.Debug|x86.Build.0 = Debug|Any CPU
+		{0189AE3B-4B8E-4DD9-87E5-3F2FF301F7B0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0189AE3B-4B8E-4DD9-87E5-3F2FF301F7B0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0189AE3B-4B8E-4DD9-87E5-3F2FF301F7B0}.Release|arm64.ActiveCfg = Release|Any CPU
+		{0189AE3B-4B8E-4DD9-87E5-3F2FF301F7B0}.Release|arm64.Build.0 = Release|Any CPU
+		{0189AE3B-4B8E-4DD9-87E5-3F2FF301F7B0}.Release|x86.ActiveCfg = Release|Any CPU
+		{0189AE3B-4B8E-4DD9-87E5-3F2FF301F7B0}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/BuildTimeHistory/BuildTimeHistory.csproj
+++ b/src/BuildTimeHistory/BuildTimeHistory.csproj
@@ -47,7 +47,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="BuildTimeHistoryPackage.cs" />
-    <Compile Include="HistoryRecord.cs" />
+    <Compile Include="Enums\BuildCompletionStatus.cs" />
+    <Compile Include="Models\BuildHistoryItem.cs" />
+    <Compile Include="Models\DailyBuildHistory.cs" />
     <Compile Include="OutputPane.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="source.extension.cs">
@@ -55,8 +57,6 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>source.extension.vsixmanifest</DependentUpon>
     </Compile>
-    <Compile Include="SponsorDetector.cs" />
-    <Compile Include="SponsorRequestHelper.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="signvsix.targets" />

--- a/src/BuildTimeHistory/BuildTimeHistory.csproj
+++ b/src/BuildTimeHistory/BuildTimeHistory.csproj
@@ -50,8 +50,10 @@
     <Compile Include="Enums\BuildCompletionStatus.cs" />
     <Compile Include="Models\BuildHistoryItem.cs" />
     <Compile Include="Models\DailyBuildHistory.cs" />
+    <Compile Include="Models\SolutionBuildHistory.cs" />
     <Compile Include="OutputPane.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Services\BuildHistoryService.cs" />
     <Compile Include="source.extension.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/src/BuildTimeHistory/BuildTimeHistoryPackage.cs
+++ b/src/BuildTimeHistory/BuildTimeHistoryPackage.cs
@@ -5,6 +5,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using BuildTimeHistory.Models;
 using Humanizer;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell;
@@ -56,49 +57,10 @@ namespace BuildTimeHistory
             sbm = ServiceProvider.GlobalProvider.GetService(typeof(SVsSolutionBuildManager)) as IVsSolutionBuildManager2;
             sbm?.AdviseUpdateSolutionEvents(this, out updateSolutionEventsCookie);
 
-            await OutputPane.Instance.WriteAsync($"{Vsix.Name} v{Vsix.Version}");
-
-            await SponsorRequestHelper.CheckIfNeedToShowAsync();
-
-            var (latestRecord, daysAgo) = await GetMostRecentDaysRecordAsync();
-
-            if (daysAgo > int.MinValue && latestRecord.TotalCount > 0)
-            {
-                var sb = new StringBuilder();
-
-                if (daysAgo == 0)
-                {
-                    sb.Append("Today's build summary: ");
-                }
-                else if (daysAgo == 1)
-                {
-                    sb.Append("Yesterday's build summary: ");
-                }
-                else
-                {
-                    sb.Append($"Build summary for {DateTime.Now.AddDays(daysAgo):dddd, MMMM d} : ");
-                }
-
-                sb.Append($"{latestRecord.TotalCount} builds ");
-
-                if (latestRecord.HasMultipleDifferentResults)
-                {
-                    sb.Append($"({latestRecord.SuccessCount} successful, {latestRecord.FailCount} failed, {latestRecord.CancelCount} cancelled) ");
-                }
-
-                var totalBuildTime = TimeSpan.FromMilliseconds(latestRecord.CalculatedTotalBuildTime);
-
-                sb.AppendLine($"taking a total of {totalBuildTime.Humanize()} ({totalBuildTime.Hours:00}:{totalBuildTime.Minutes:00}:{totalBuildTime.Seconds:00})");
-
-
-                await OutputPane.Instance.WriteAsync(sb.ToString());
-            }
-            else
-            {
-                await OutputPane.Instance.WriteAsync("No previous history available.");
-            }
+            await OutputPane.Instance.WriteAsync($"{Vsix.Name} v{Vsix.Version}");            
         }
 
+        #region Unused Interface
         public int OnAfterOpenProject(IVsHierarchy pHierarchy, int fAdded)
         {
             return VSConstants.S_OK;
@@ -129,11 +91,6 @@ namespace BuildTimeHistory
             return VSConstants.S_OK;
         }
 
-        public int OnAfterOpenSolution(object pUnkReserved, int fNewSolution)
-        {
-            return VSConstants.S_OK;
-        }
-
         public int OnQueryCloseSolution(object pUnkReserved, ref int pfCancel)
         {
             return VSConstants.S_OK;
@@ -146,22 +103,6 @@ namespace BuildTimeHistory
 
         public int OnAfterCloseSolution(object pUnkReserved)
         {
-            return VSConstants.S_OK;
-        }
-
-        readonly Stopwatch _buildTimer = new Stopwatch();
-
-        public int UpdateSolution_Begin(ref int pfCancelUpdate)
-        {
-            _buildTimer.Restart();
-
-            return VSConstants.S_OK;
-        }
-
-        public int UpdateSolution_Done(int fSucceeded, int fModified, int fCancelCommand)
-        {
-            ProcessFinish(fSucceeded == 1, fCancelCommand == 1);
-
             return VSConstants.S_OK;
         }
 
@@ -188,6 +129,118 @@ namespace BuildTimeHistory
         public int UpdateProjectCfg_Done(IVsHierarchy pHierProj, IVsCfg pCfgProj, IVsCfg pCfgSln, uint dwAction, int fSuccess, int fCancel)
         {
             return VSConstants.S_OK;
+        } 
+        #endregion
+
+
+        readonly Stopwatch _buildTimer = new Stopwatch();
+
+        public int OnAfterOpenSolution(object pUnkReserved, int fNewSolution)
+        {
+            SolutionOpen();
+            return VSConstants.S_OK;
+        }
+
+        public int UpdateSolution_Begin(ref int pfCancelUpdate)
+        {
+            _buildTimer.Restart();
+
+            return VSConstants.S_OK;
+        }
+
+        public int UpdateSolution_Done(int fSucceeded, int fModified, int fCancelCommand)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            ProcessFinish(fSucceeded == 1, fCancelCommand == 1);
+
+            return VSConstants.S_OK;
+        }
+
+        private string GetHistoryFilePath(string solutionName, int daysPast = 0)
+        {
+            var dateOfInstrest = DateTime.Now.AddDays(-daysPast);
+
+            var day = dateOfInstrest.ToString("yyyy-MM-dd");
+
+            var path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                "BuildTimeTracker",
+                solutionName,
+                dateOfInstrest.ToString("yyyy-MM"),
+                $"{day}.json");
+
+            return path;
+        }
+
+        private async Task SaveTodaysRecordAsync(string solutionName, DailyBuildHistory record)
+        {
+            try
+            {
+                var path = GetHistoryFilePath(solutionName);
+
+                var dir = Path.GetDirectoryName(path);
+
+                if (!Directory.Exists(dir))
+                {
+                    Directory.CreateDirectory(dir);
+                }
+
+                File.WriteAllText(path, JsonConvert.SerializeObject(record));
+            }
+            catch (Exception ex)
+            {
+                await OutputPane.Instance.WriteAsync("Failed to save history file for today");
+                await OutputPane.Instance.WriteAsync(ex.Message);
+                await OutputPane.Instance.WriteAsync(ex.Source);
+                await OutputPane.Instance.WriteAsync(ex.StackTrace);
+            }
+        }
+
+        private async Task<(DailyBuildHistory, int)> GetMostRecentDaysRecordAsync(string solutionName)
+        {
+            try
+            {
+                for (int i = 0; i < 100; i++)
+                {
+                    var path = GetHistoryFilePath(solutionName, i);
+
+                    if (File.Exists(path))
+                    {
+                        return (JsonConvert.DeserializeObject<DailyBuildHistory>(File.ReadAllText(path)), i);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                await OutputPane.Instance.WriteAsync("Failed to load history file for today");
+                await OutputPane.Instance.WriteAsync(ex.Message);
+                await OutputPane.Instance.WriteAsync(ex.Source);
+                await OutputPane.Instance.WriteAsync(ex.StackTrace);
+            }
+
+            return (new DailyBuildHistory(), int.MinValue);
+        }
+
+        private async Task<DailyBuildHistory> GetTodaysRecordAsync(string solutionName)
+        {
+            try
+            {
+                var path = GetHistoryFilePath(solutionName);
+
+                if (File.Exists(path))
+                {
+                    return JsonConvert.DeserializeObject<DailyBuildHistory>(File.ReadAllText(path));
+                }
+            }
+            catch (Exception ex)
+            {
+                await OutputPane.Instance.WriteAsync("Failed to load history file for today");
+                await OutputPane.Instance.WriteAsync(ex.Message);
+                await OutputPane.Instance.WriteAsync(ex.Source);
+                await OutputPane.Instance.WriteAsync(ex.StackTrace);
+            }
+
+            return new DailyBuildHistory();
         }
 
         private void ProcessFinish(bool wasSuccessful, bool wasCancelled)
@@ -195,10 +248,8 @@ namespace BuildTimeHistory
             // If a build was started before the extension package loaded the time won't have been started.
             bool includeTimeInHistory = _buildTimer.IsRunning;
 
-            // Stop the timer before switching thread
             _buildTimer.Stop();
 
-#pragma warning disable VSTHRD102 // Implement internal logic asynchronously - can't make IVsUpdateSolutionEvents2 methods async
             ThreadHelper.JoinableTaskFactory.Run(async delegate
             {
                 await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
@@ -206,45 +257,49 @@ namespace BuildTimeHistory
                 try
                 {
                     var buildDuration = _buildTimer.ElapsedMilliseconds;
+                    var solutionName = GetCurrentSolutionName();
 
-                    var todaysRecord = await GetTodaysRecordAsync();
+                    var todaysRecord = await GetTodaysRecordAsync(solutionName);
 
                     var sb = new StringBuilder();
 
-                    sb.Append($"{DateTime.Now.ToShortTimeString()}> ");
+                    sb.Append($"{DateTime.Now.ToShortTimeString()}>");
 
                     if (wasSuccessful)
                     {
                         sb.AppendLine($"Build completed successfully after {TimeSpan.FromMilliseconds(buildDuration).Humanize()}");
-                        todaysRecord.SuccessCount++;
+                        BuildHistoryItem item = new BuildHistoryItem { RecordDate = DateTime.Now, Status = Enums.BuildCompletionStatus.Succeeded };
 
                         if (includeTimeInHistory)
                         {
-                            todaysRecord.SuccessBuildTime += buildDuration;
+                            item.BuildTime = buildDuration;
                         }
+
+                        todaysRecord.BuildHistory.Add(item);
+                    }
+                    else if (wasCancelled)
+                    {
+                        sb.AppendLine($"Build was cancelled after {TimeSpan.FromMilliseconds(buildDuration).Humanize()}");
+                        BuildHistoryItem item = new BuildHistoryItem { RecordDate = DateTime.Now, Status = Enums.BuildCompletionStatus.Cancelled };
+
+                        if (includeTimeInHistory)
+                        {
+                            item.BuildTime = buildDuration;
+                        }
+
+                        todaysRecord.BuildHistory.Add(item);
                     }
                     else
                     {
-                        if (wasCancelled)
-                        {
-                            sb.AppendLine($"Build was cancelled after {TimeSpan.FromMilliseconds(buildDuration).Humanize()}");
-                            todaysRecord.CancelCount++;
+                        sb.AppendLine($"Build failed after {TimeSpan.FromMilliseconds(buildDuration).Humanize()}");
+                        BuildHistoryItem item = new BuildHistoryItem { RecordDate = DateTime.Now, Status = Enums.BuildCompletionStatus.Failed };
 
-                            if (includeTimeInHistory)
-                            {
-                                todaysRecord.CancelBuildTime += buildDuration;
-                            }
-                        }
-                        else
+                        if (includeTimeInHistory)
                         {
-                            sb.AppendLine($"Build failed after {TimeSpan.FromMilliseconds(buildDuration).Humanize()}");
-                            todaysRecord.FailCount++;
-
-                            if (includeTimeInHistory)
-                            {
-                                todaysRecord.FailBuildTime += buildDuration;
-                            }
+                            item.BuildTime = buildDuration;
                         }
+
+                        todaysRecord.BuildHistory.Add(item);
                     }
 
                     if (!includeTimeInHistory)
@@ -252,112 +307,94 @@ namespace BuildTimeHistory
                         await OutputPane.Instance.WriteAsync("** Build time is unavailable and won't be added to the cumulative history.");
                     }
 
-                    await SaveTodaysRecordAsync(todaysRecord);
+                    await SaveTodaysRecordAsync(solutionName, todaysRecord);
+
+                    var totalBuildTime = TimeSpan.FromMilliseconds(todaysRecord.TotalBuildTime);
+                    var averageBuildTime = TimeSpan.FromMilliseconds(todaysRecord.AverageBuildTime);
 
                     sb.Append($"Today's build summary: ");
-                    sb.Append($"{todaysRecord.TotalCount} build{(todaysRecord.TotalCount > 1 ? "s" : string.Empty)} ");
-
-                    if (todaysRecord.HasMultipleDifferentResults)
-                    {
-                        sb.Append($"({todaysRecord.SuccessCount} successful, {todaysRecord.FailCount} failed, {todaysRecord.CancelCount} cancelled) ");
-                    }
-
-                    var totalBuildTime = TimeSpan.FromMilliseconds(todaysRecord.CalculatedTotalBuildTime);
-
-                    sb.AppendLine($"taking a total of {totalBuildTime.Humanize()} ({totalBuildTime.Hours:00}:{totalBuildTime.Minutes:00}:{totalBuildTime.Seconds:00})");
+                    sb.Append($"{todaysRecord.TotalCount} build {(todaysRecord.TotalCount > 1 ? "s" : string.Empty)} ");
+                    sb.Append($"({todaysRecord.TotalSuccess} successful, {todaysRecord.TotalFailed} failed, {todaysRecord.TotalCancelled} cancelled) ");
+                    sb.Append($"taking a total of {totalBuildTime.Humanize()} ({totalBuildTime.Hours:00}:{totalBuildTime.Minutes:00}:{totalBuildTime.Seconds:00}) ");
+                    sb.Append($"with an average of {averageBuildTime.Humanize()} ({averageBuildTime.Hours:00}:{averageBuildTime.Minutes:00}:{averageBuildTime.Seconds:00}) per build ");
 
                     await OutputPane.Instance.WriteAsync(sb.ToString());
                 }
-                catch (Exception exc)
+                catch (Exception ex)
                 {
-                    System.Diagnostics.Debug.WriteLine(exc.Message);
-                    await OutputPane.Instance.WriteAsync(exc.Message);
+                    System.Diagnostics.Debug.WriteLine(ex.Message);
+                    await OutputPane.Instance.WriteAsync(ex.Message);
                 }
             });
-#pragma warning restore VSTHRD102 // Implement internal logic asynchronously
         }
 
-        private async Task SaveTodaysRecordAsync(HistoryRecord todaysRecord)
+        private string GetCurrentSolutionName()
         {
-            try
-            {
-                var path = GetHistoryFilePath();
+            ThreadHelper.ThrowIfNotOnUIThread();
 
-                var dir = Path.GetDirectoryName(path);
-                if (!Directory.Exists(dir))
+            if (solution != null)
+            {
+                solution.GetSolutionInfo(out string solutionDirectory, out string solutionFile, out string userOptionsFile);
+
+                if (!string.IsNullOrWhiteSpace(solutionFile))
                 {
-                    Directory.CreateDirectory(dir);
+                    return System.IO.Path.GetFileNameWithoutExtension(solutionFile);
                 }
+            }
 
-                File.WriteAllText(path, JsonConvert.SerializeObject(todaysRecord));
-            }
-            catch (Exception exc)
-            {
-                await OutputPane.Instance.WriteAsync("Failed to load history file to save todays data");
-                await OutputPane.Instance.WriteAsync(exc.Message);
-                await OutputPane.Instance.WriteAsync(exc.Source);
-                await OutputPane.Instance.WriteAsync(exc.StackTrace);
-            }
+            return string.Empty;
         }
 
-        private string GetHistoryFilePath(int daysPast = 0)
+        private void SolutionOpen()
         {
-            var dateOfInterest = DateTime.Now.AddDays(-daysPast);
-
-            return Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                "BuildTimerHistory",
-                dateOfInterest.Year.ToString(),
-                dateOfInterest.Month.ToString(),
-                $"{dateOfInterest.Day}.data");
-        }
-
-        private async Task<(HistoryRecord, int)> GetMostRecentDaysRecordAsync()
-        {
-            try
+            ThreadHelper.JoinableTaskFactory.Run(async delegate
             {
-                // Quick easy approach of all possible history is only looking at the last 100 days
-                for (int i = 0; i < 100; i++)
+                try
                 {
-                    var path = GetHistoryFilePath(i);
+                    var solutionName = GetCurrentSolutionName();
 
-                    if (File.Exists(path))
+                    var (latestRecord, daysAgo) = await GetMostRecentDaysRecordAsync(solutionName);
+
+                    if (daysAgo > int.MinValue && latestRecord.TotalCount > 0)
                     {
-                        return (JsonConvert.DeserializeObject<HistoryRecord>(File.ReadAllText(path)), i);
+                        var sb = new StringBuilder();
+
+                        if (daysAgo == 0)
+                        {
+                            sb.Append("Today's build summary: ");
+                        }
+                        else if (daysAgo == 1)
+                        {
+                            sb.Append("Yesterday's build summary: ");
+                        }
+                        else
+                        {
+                            sb.Append($"Build summary for {DateTime.Now.AddDays(daysAgo):dddd, MMMM d} : ");
+                        }
+
+                        var totalBuildTime = TimeSpan.FromMilliseconds(latestRecord.TotalBuildTime);
+                        var averageBuildTime = TimeSpan.FromMilliseconds(latestRecord.AverageBuildTime);
+
+                        sb.Append($"{latestRecord.TotalCount} build{(latestRecord.TotalCount > 1 ? "s" : string.Empty)} ");
+                        sb.Append($"({latestRecord.TotalSuccess} successful, {latestRecord.TotalFailed} failed, {latestRecord.TotalCancelled} cancelled) ");
+                        sb.Append($"taking a total of {totalBuildTime.Humanize()} ({totalBuildTime.Hours:00}:{totalBuildTime.Minutes:00}:{totalBuildTime.Seconds:00})");
+                        sb.Append($"with an average of {averageBuildTime.Humanize()} ({averageBuildTime.Hours:00}:{averageBuildTime.Minutes:00}:{averageBuildTime.Seconds:00}) per build");
+
+
+                        await OutputPane.Instance.WriteAsync(sb.ToString());
+                    }
+                    else
+                    {
+                        await OutputPane.Instance.WriteAsync("No previous history available.");
                     }
                 }
-            }
-            catch (Exception exc)
-            {
-                await OutputPane.Instance.WriteAsync("Failed to load history file for today");
-                await OutputPane.Instance.WriteAsync(exc.Message);
-                await OutputPane.Instance.WriteAsync(exc.Source);
-                await OutputPane.Instance.WriteAsync(exc.StackTrace);
-            }
-
-            return (HistoryRecord.CreateNew(), int.MinValue);
-        }
-
-        private async Task<HistoryRecord> GetTodaysRecordAsync()
-        {
-            try
-            {
-                var path = GetHistoryFilePath();
-
-                if (File.Exists(path))
+                catch (Exception ex)
                 {
-                    return JsonConvert.DeserializeObject<HistoryRecord>(File.ReadAllText(path));
+                    System.Diagnostics.Debug.WriteLine(ex.Message);
+                    await OutputPane.Instance.WriteAsync(ex.Message);
                 }
-            }
-            catch (Exception exc)
-            {
-                await OutputPane.Instance.WriteAsync("Failed to load history file for today");
-                await OutputPane.Instance.WriteAsync(exc.Message);
-                await OutputPane.Instance.WriteAsync(exc.Source);
-                await OutputPane.Instance.WriteAsync(exc.StackTrace);
-            }
+            });
 
-            return HistoryRecord.CreateNew();
         }
     }
 }

--- a/src/BuildTimeHistory/BuildTimeHistoryPackage.cs
+++ b/src/BuildTimeHistory/BuildTimeHistoryPackage.cs
@@ -307,7 +307,7 @@ namespace BuildTimeHistory
                     var averageBuildTime = TimeSpan.FromMilliseconds(todaysRecord.AverageBuildTime);
 
                     sb.Append($"Today's build summary: ");
-                    sb.Append($"{todaysRecord.TotalCount} build {(todaysRecord.TotalCount > 1 ? "s" : string.Empty)} ");
+                    sb.Append($"{todaysRecord.TotalCount} build{(todaysRecord.TotalCount > 1 ? "s" : string.Empty)} ");
                     sb.Append($"({todaysRecord.TotalSuccess} successful, {todaysRecord.TotalFailed} failed, {todaysRecord.TotalCancelled} cancelled) ");
                     sb.Append($"taking a total of {totalBuildTime.Humanize()} ({totalBuildTime.Hours:00}:{totalBuildTime.Minutes:00}:{totalBuildTime.Seconds:00}) ");
                     sb.Append($"with an average of {averageBuildTime.Humanize()} ({averageBuildTime.Hours:00}:{averageBuildTime.Minutes:00}:{averageBuildTime.Seconds:00}) per build ");

--- a/src/BuildTimeHistory/Enums/BuildCompletionStatus.cs
+++ b/src/BuildTimeHistory/Enums/BuildCompletionStatus.cs
@@ -8,9 +8,9 @@ namespace BuildTimeHistory.Enums
 {
     public enum BuildCompletionStatus
     {
-        Unknown,
-        Succeeded,
-        Failed,
-        Cancelled
+        Unknown = 0,
+        Succeeded = 1,
+        Failed = 2,
+        Cancelled = 3
     }
 }

--- a/src/BuildTimeHistory/Enums/BuildCompletionStatus.cs
+++ b/src/BuildTimeHistory/Enums/BuildCompletionStatus.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BuildTimeHistory.Enums
+{
+    public enum BuildCompletionStatus
+    {
+        Unknown,
+        Succeeded,
+        Failed,
+        Cancelled
+    }
+}

--- a/src/BuildTimeHistory/Models/BuildHistoryItem.cs
+++ b/src/BuildTimeHistory/Models/BuildHistoryItem.cs
@@ -1,0 +1,16 @@
+﻿using BuildTimeHistory.Enums;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BuildTimeHistory.Models
+{
+    public class BuildHistoryItem
+    {
+        public DateTime RecordDate { get; set; }
+        public BuildCompletionStatus Status { get; set; } = BuildCompletionStatus.Unknown;
+        public double BuildTime { get; set; }
+    }
+}

--- a/src/BuildTimeHistory/Models/DailyBuildHistory.cs
+++ b/src/BuildTimeHistory/Models/DailyBuildHistory.cs
@@ -1,0 +1,41 @@
+﻿using BuildTimeHistory.Enums;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BuildTimeHistory.Models
+{
+    public class DailyBuildHistory
+    {
+        public DateTime Date { get; set; }
+
+        [JsonIgnore]
+        public int TotalCount => BuildHistory.Count;
+
+        [JsonIgnore]
+        public int TotalSuccess => BuildHistory.Count(x => x.Status == BuildCompletionStatus.Succeeded);
+
+        [JsonIgnore]
+        public int TotalFailed => BuildHistory.Count(x => x.Status == BuildCompletionStatus.Failed);
+
+        [JsonIgnore]
+        public int TotalCancelled => BuildHistory.Count(x => x.Status == BuildCompletionStatus.Cancelled);
+
+        public List<BuildHistoryItem> BuildHistory { get; set; }
+
+        [JsonIgnore]
+        public double AverageBuildTime => BuildHistory.Average(x => x.BuildTime);
+
+        [JsonIgnore]
+        public double TotalBuildTime => BuildHistory.Sum(x => x.BuildTime);
+
+        public DailyBuildHistory()
+        {
+            Date = DateTime.Now;
+            BuildHistory = new List<BuildHistoryItem>();
+        }        
+    }
+}

--- a/src/BuildTimeHistory/Models/SolutionBuildHistory.cs
+++ b/src/BuildTimeHistory/Models/SolutionBuildHistory.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BuildTimeHistory.Models
+{
+    public class SolutionBuildHistory
+    {
+        public string SolutionName { get; set; }
+
+        public int DaysToKeep { get; set; } = 0;
+
+        public DateTime LastUpdated { get; set; }
+
+        public DateTime DateCreated { get; set; }
+
+        public List<DailyBuildHistory> DailyBuildHistory { get; set; }
+
+        public SolutionBuildHistory()
+        {
+            DailyBuildHistory = new List<DailyBuildHistory>();
+            DateCreated = DateTime.Now;
+            LastUpdated = DateTime.Now;
+        }
+    }
+}

--- a/src/BuildTimeHistory/Services/BuildHistoryService.cs
+++ b/src/BuildTimeHistory/Services/BuildHistoryService.cs
@@ -1,0 +1,129 @@
+﻿using BuildTimeHistory.Models;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BuildTimeHistory.Services
+{
+    public class BuildHistoryService
+    {
+        private SolutionBuildHistory _buildHistory;
+        private string _fileBasePath;
+        private bool _isInitialized;
+        private string _solutionName;
+
+        public SolutionBuildHistory BuildHistory { get { return _buildHistory; } }
+        
+        public bool IsInitialized { get { return _isInitialized; } }
+
+        public string FilePath { get { return Path.Combine(_fileBasePath, $"{_solutionName}.dat"); } }
+
+        public string SolutionName { get { return _solutionName; } }
+
+        public BuildHistoryService()
+        {
+            _fileBasePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                "BuildTimeTracker");
+        }
+
+        public BuildHistoryService(string fileBasePath)
+        {
+            _fileBasePath = fileBasePath;
+        }
+
+        public bool Initialize(string solutionName)
+        {
+            _solutionName = solutionName;
+
+            try
+            {
+                if (File.Exists(FilePath))
+                {
+                    _buildHistory = JsonConvert.DeserializeObject<SolutionBuildHistory>(File.ReadAllText(FilePath));
+                }
+                else
+                {
+                    _buildHistory = new SolutionBuildHistory() { SolutionName = _solutionName };
+                }
+            }
+            catch (Exception)
+            {
+                _isInitialized = false;
+                return false;
+            }
+
+            _isInitialized = true;
+            return true;
+        }
+
+        public DailyBuildHistory GetMostRecentDayRecord()
+        {
+            ThrowIfNotInitalized();
+
+            if (_buildHistory.DailyBuildHistory.Count == 0)
+            {
+                return null;
+            }
+            else if (_buildHistory.DailyBuildHistory.Count == 1)
+            {
+                return _buildHistory.DailyBuildHistory.First();
+            }
+            else
+            {
+                var item = _buildHistory.DailyBuildHistory.OrderByDescending(d => d.Date).FirstOrDefault();
+                return item;
+            }
+        }
+
+        public DailyBuildHistory GetTodaysRecord()
+        {
+            ThrowIfNotInitalized();
+
+            var record = _buildHistory.DailyBuildHistory.SingleOrDefault(x => x.Date.Date == DateTime.Today.Date);
+            return record;
+        }
+
+        public bool AddRecord(BuildHistoryItem record)
+        {            
+            _buildHistory.LastUpdated = DateTime.Now;
+            
+            var dailyRecord = GetTodaysRecord();
+            dailyRecord.BuildHistory.Add(record);
+            return true;
+        }
+
+        public bool Save()
+        {
+            ThrowIfNotInitalized();
+            
+            if (!Directory.Exists(_fileBasePath))
+            {
+                Directory.CreateDirectory(_fileBasePath);
+            }
+
+            File.WriteAllText(FilePath, JsonConvert.SerializeObject(_buildHistory));
+
+            return true;
+        }
+
+        public bool Refresh()
+        {
+            ThrowIfNotInitalized();
+            Initialize(_solutionName);
+            return true;
+        }
+
+        private void ThrowIfNotInitalized()
+        {
+            if (!_isInitialized)
+            {
+                throw new InvalidOperationException("Solution History has not been initalized"); 
+            }
+        }
+    }
+}

--- a/src/BuildTimeHistory/Services/BuildHistoryService.cs
+++ b/src/BuildTimeHistory/Services/BuildHistoryService.cs
@@ -48,7 +48,7 @@ namespace BuildTimeHistory.Services
                 }
                 else
                 {
-                    _buildHistory = new SolutionBuildHistory() { SolutionName = _solutionName };
+                    _buildHistory = new SolutionBuildHistory() { SolutionName = _solutionName, DateCreated = DateTime.Now, LastUpdated = DateTime.Now };
                 }
             }
             catch (Exception)
@@ -80,11 +80,23 @@ namespace BuildTimeHistory.Services
             }
         }
 
+
         public DailyBuildHistory GetTodaysRecord()
         {
             ThrowIfNotInitalized();
 
             var record = _buildHistory.DailyBuildHistory.SingleOrDefault(x => x.Date.Date == DateTime.Today.Date);
+
+            if (record == null)
+            {
+                record = new DailyBuildHistory()
+                {
+                    Date = DateTime.Now
+                };
+
+                _buildHistory.DailyBuildHistory.Add(record);
+            }
+
             return record;
         }
 
@@ -100,15 +112,22 @@ namespace BuildTimeHistory.Services
         public bool Save()
         {
             ThrowIfNotInitalized();
-            
-            if (!Directory.Exists(_fileBasePath))
+
+            try
             {
-                Directory.CreateDirectory(_fileBasePath);
+                if (!Directory.Exists(_fileBasePath))
+                {
+                    Directory.CreateDirectory(_fileBasePath);
+                }
+
+                File.WriteAllText(FilePath, JsonConvert.SerializeObject(_buildHistory));
+
+                return true;
             }
-
-            File.WriteAllText(FilePath, JsonConvert.SerializeObject(_buildHistory));
-
-            return true;
+            catch (Exception)
+            {
+                return false;
+            }
         }
 
         public bool Refresh()

--- a/src/BuildTimeHistory/source.extension.cs
+++ b/src/BuildTimeHistory/source.extension.cs
@@ -11,7 +11,7 @@ namespace BuildTimeHistory
         public const string Name = "Build Time History";
         public const string Description = @"Keep track of the total time spent waiting for code to build.";
         public const string Language = "en-US";
-        public const string Version = "1.2";
+        public const string Version = "1.3";
         public const string Author = "Matt Lacey";
         public const string Tags = "";
     }

--- a/src/SolutionBuildTimeHistory.Test/BuildHistoryServiceTest.cs
+++ b/src/SolutionBuildTimeHistory.Test/BuildHistoryServiceTest.cs
@@ -2,6 +2,7 @@
 using BuildTimeHistory.Models;
 using BuildTimeHistory.Services;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
 using System;
 using System.IO;
 
@@ -10,18 +11,23 @@ namespace SolutionBuildTimeHistory.Test
     [TestClass]
     public class BuildHistoryServiceTest
     {
-        private string _emptyFileName = "NoData";
-        private string _yesterdayFileName = "Yesterday";
-        private string _todayFileName = "Today";
+        private const string _emptyFileName = "NoData";
+        private const string _yesterdayFileName = "Yesterday";
+        private const string _todayFileName = "Today";
+        private const string _unknownLastDateFileName = "Unknown";
+
         private string _testPath = "D:\\Workspace\\Programming\\Test Data";
 
         private Random _random = new Random();
 
-        //[TestInitialize]
-        //public void Init()
-        //{
-
-        //}
+        [TestInitialize]
+        public void Init()
+        {
+            Cleanup();
+            GenerateTestFile(_todayFileName, 5);
+            GenerateTestFile(_yesterdayFileName, 5, excludeToday: true);
+            GenerateTestFile(_unknownLastDateFileName, randomDays: true);
+        }
 
         [TestCleanup]
         public void Cleanup()
@@ -43,67 +49,155 @@ namespace SolutionBuildTimeHistory.Test
         }
 
         [TestMethod]
-        [DataRow("Today")]
-        [DataRow("Yesterday")]
-        [DataRow("NoData")]
+        [DataRow(_todayFileName)]
+        [DataRow(_yesterdayFileName)]
+        [DataRow(_emptyFileName)]
+        [DataRow(_unknownLastDateFileName)]
         public void GetMostRecentDayRecord_ReturnsDailyBuildHistory(string solutionName)
         {            
-            BuildHistoryService service;
-            bool initResult = false;
-            DailyBuildHistory buildDay;
+            BuildHistoryService service = new BuildHistoryService(_testPath); 
+            bool initResult = service.Initialize(solutionName);
+            
+            Assert.IsTrue(initResult, $"Unable to initialize service for solution: {solutionName}");
+
+            DailyBuildHistory buildDay = service.GetMostRecentDayRecord();
 
             switch (solutionName)
             {
-                case "Today":
-                    GenerateTestFile(solutionName, 5, 10, false);
-                    service = new BuildHistoryService(_testPath);
-                    initResult = service.Initialize(solutionName);
-                    Assert.IsTrue(initResult, $"Unable to initialize service for solution: {solutionName}");
-
-                    buildDay = service.GetMostRecentDayRecord();
-
-                    Assert.IsTrue(buildDay.Date.Date == DateTime.Now.Date);
+                case _todayFileName:                                       
+                    Assert.IsTrue(buildDay.Date.Date == DateTime.Now.Date, "No Data for Today");
                     break;
-                case "Yesterday":
-                    GenerateTestFile(solutionName, 5, 10, true);
-                    service = new BuildHistoryService(_testPath);
-                    initResult = service.Initialize(solutionName);
-                    Assert.IsTrue(initResult, $"Unable to initialize service for solution: {solutionName}");
-
-                    buildDay = service.GetMostRecentDayRecord();
-
-                    Assert.IsTrue(buildDay.Date.Date == DateTime.Now.Date.AddDays(-1));
+                case _yesterdayFileName:
+                    Assert.IsTrue(buildDay.Date.Date == DateTime.Now.Date.AddDays(-1), "No Data for Yesterday");
                     break;
-                case "NoData":                   
-                    service = new BuildHistoryService(_testPath);
-                    initResult = service.Initialize(solutionName);
-                    Assert.IsTrue(initResult, $"Unable to initialize service for solution: {solutionName}");
-
-                    buildDay = service.GetMostRecentDayRecord();
-
-                    Assert.IsTrue(buildDay == null);
+                case _emptyFileName:                                       
+                    Assert.IsTrue(buildDay == null, "Empty Solution is not Empty");
+                    break;
+                case _unknownLastDateFileName:
+                    Assert.IsTrue(buildDay != null);
                     break;
                 default:
                     Assert.Fail($"Solution Name Not MappedL: {solutionName}");
                     break;
             }
+        }
 
+        [TestMethod]
+        [DataRow(_todayFileName)]
+        [DataRow(_yesterdayFileName)]
+        public void GetTodaysRecord_ReturnsDailyBuildHistory(string solutionName)
+        {
+            BuildHistoryService service = new BuildHistoryService(solutionName);
+            bool initResult = service.Initialize(solutionName);
+
+            Assert.IsTrue(initResult, $"Unable to initialize service for solution: {solutionName}");
+
+            DailyBuildHistory buildDay = service.GetTodaysRecord();
+
+            Assert.IsTrue(buildDay.Date.Date == DateTime.Now.Date);
+        }
+
+        [TestMethod]
+        public void AddRecord_returnsBoolean()
+        {
+            BuildHistoryService service = new BuildHistoryService(_todayFileName);
+            bool initResult = service.Initialize(_todayFileName);
+
+            Assert.IsTrue(initResult, $"Unable to initialize service for solution: {_todayFileName}");
+
+            var historyItem = new BuildHistoryItem()
+            {
+                BuildTime = RandomBuildTime(),
+                RecordDate = DateTime.Now,
+                Status = RandomStatus()
+            };
+
+            var result = service.AddRecord(historyItem);
+            Assert.IsTrue(result, "Unable to Add History Item");
+            Assert.IsTrue(service.GetTodaysRecord().BuildHistory.Contains(historyItem), "History Item was not found in Build History");
+        }
+
+        [TestMethod]
+        public void Save_ReturnsBool()
+        {
+            var solutionName = "SaveTest";
+            BuildHistoryService service = new BuildHistoryService(_testPath);
+            bool initResult = service.Initialize(solutionName);
+
+            Assert.IsTrue(initResult, $"Unable to initialize service for solution: {solutionName}");
+
+            var currentDate = new DateTime(2024, 06, 01);
+
+            service.BuildHistory.DateCreated = currentDate;
+            service.BuildHistory.LastUpdated = currentDate;
+
+            DailyBuildHistory dailyHistoryItem = new DailyBuildHistory()
+            {
+                Date = currentDate,
+                BuildHistory = new System.Collections.Generic.List<BuildHistoryItem>()
+            };
+
+            dailyHistoryItem.BuildHistory.Add(new BuildHistoryItem()
+            {
+                BuildTime = 1000,
+                RecordDate = currentDate,
+                Status = BuildCompletionStatus.Succeeded
+            });
+
+            service.BuildHistory.DailyBuildHistory.Add(dailyHistoryItem);
+
+            var result = service.Save();
+            Assert.IsTrue(result);
+
+            var expected = "{\"SolutionName\":\"SaveTest\",\"DaysToKeep\":0,\"LastUpdated\":\"2024-06-01T00:00:00\",\"DateCreated\":\"2024-06-01T00:00:00\",\"DailyBuildHistory\":[{\"Date\":\"2024-06-01T00:00:00\",\"BuildHistory\":[{\"RecordDate\":\"2024-06-01T00:00:00\",\"Status\":1,\"BuildTime\":1000.0}]}]}";
+
+            var actual = File.ReadAllText(service.FilePath);
+
+            Assert.AreEqual(expected, actual);
         }
 
 
-        private void GenerateTestFile(string solutionName, int numDaysToPreload, int numBuildsToSimulate, bool excludeToday)
+        private void GenerateTestFile(string solutionName, int numDaysToPreload = 0, int numBuildsToSimulate = 0, bool excludeToday = false, bool randomDays = false)
         {
             var service = new BuildHistoryService(_testPath);
             var initResult = service.Initialize(solutionName);
 
             var solutionHistory = service.BuildHistory;
 
+            bool todayExcluded = false;
+
+            if (numDaysToPreload == 0)
+            {
+                numDaysToPreload = _random.Next(1, 31);
+            }
+
             for (int i = 0; i < numDaysToPreload; i++)
             {
-                if (excludeToday) { i++; }
+                if (excludeToday && !todayExcluded) 
+                { 
+                    i++;
+                    numDaysToPreload++;
+                    todayExcluded = true;
+                }
 
-                var daysPast = i * -1;
-                var currentDay = DateTime.Now.AddDays(daysPast);
+                DateTime currentDay;
+
+                if (!randomDays)
+                {
+                    var daysPast = i * -1;
+                    currentDay = DateTime.Now.AddDays(daysPast);
+                }
+                else
+                {
+                    var randomMonth = _random.Next(1, 12);
+                    var randomDay = _random.Next(1, 28);
+                    currentDay = new DateTime(DateTime.Now.Year, randomMonth, randomDay);
+                }
+
+                if (numBuildsToSimulate == 0)
+                {
+                    numBuildsToSimulate = _random.Next(1, 20);
+                }
 
                 var day = new BuildTimeHistory.Models.DailyBuildHistory()
                 {

--- a/src/SolutionBuildTimeHistory.Test/BuildHistoryServiceTest.cs
+++ b/src/SolutionBuildTimeHistory.Test/BuildHistoryServiceTest.cs
@@ -1,0 +1,143 @@
+﻿using BuildTimeHistory.Enums;
+using BuildTimeHistory.Models;
+using BuildTimeHistory.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+
+namespace SolutionBuildTimeHistory.Test
+{
+    [TestClass]
+    public class BuildHistoryServiceTest
+    {
+        private string _emptyFileName = "NoData";
+        private string _yesterdayFileName = "Yesterday";
+        private string _todayFileName = "Today";
+        private string _testPath = "D:\\Workspace\\Programming\\Test Data";
+
+        private Random _random = new Random();
+
+        //[TestInitialize]
+        //public void Init()
+        //{
+
+        //}
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            Array.ForEach(Directory.GetFiles(_testPath), File.Delete);
+        }
+
+
+        [TestMethod]
+        public void Initialize_ReturnsTrue()
+        {
+           
+            var solutionName = "testSolution";
+            var service = new BuildHistoryService(_testPath);
+
+            var result = service.Initialize(solutionName);
+            
+            Assert.IsTrue(service.IsInitialized, "Service Not Initailized");
+        }
+
+        [TestMethod]
+        [DataRow("Today")]
+        [DataRow("Yesterday")]
+        [DataRow("NoData")]
+        public void GetMostRecentDayRecord_ReturnsDailyBuildHistory(string solutionName)
+        {            
+            BuildHistoryService service;
+            bool initResult = false;
+            DailyBuildHistory buildDay;
+
+            switch (solutionName)
+            {
+                case "Today":
+                    GenerateTestFile(solutionName, 5, 10, false);
+                    service = new BuildHistoryService(_testPath);
+                    initResult = service.Initialize(solutionName);
+                    Assert.IsTrue(initResult, $"Unable to initialize service for solution: {solutionName}");
+
+                    buildDay = service.GetMostRecentDayRecord();
+
+                    Assert.IsTrue(buildDay.Date.Date == DateTime.Now.Date);
+                    break;
+                case "Yesterday":
+                    GenerateTestFile(solutionName, 5, 10, true);
+                    service = new BuildHistoryService(_testPath);
+                    initResult = service.Initialize(solutionName);
+                    Assert.IsTrue(initResult, $"Unable to initialize service for solution: {solutionName}");
+
+                    buildDay = service.GetMostRecentDayRecord();
+
+                    Assert.IsTrue(buildDay.Date.Date == DateTime.Now.Date.AddDays(-1));
+                    break;
+                case "NoData":                   
+                    service = new BuildHistoryService(_testPath);
+                    initResult = service.Initialize(solutionName);
+                    Assert.IsTrue(initResult, $"Unable to initialize service for solution: {solutionName}");
+
+                    buildDay = service.GetMostRecentDayRecord();
+
+                    Assert.IsTrue(buildDay == null);
+                    break;
+                default:
+                    Assert.Fail($"Solution Name Not MappedL: {solutionName}");
+                    break;
+            }
+
+        }
+
+
+        private void GenerateTestFile(string solutionName, int numDaysToPreload, int numBuildsToSimulate, bool excludeToday)
+        {
+            var service = new BuildHistoryService(_testPath);
+            var initResult = service.Initialize(solutionName);
+
+            var solutionHistory = service.BuildHistory;
+
+            for (int i = 0; i < numDaysToPreload; i++)
+            {
+                if (excludeToday) { i++; }
+
+                var daysPast = i * -1;
+                var currentDay = DateTime.Now.AddDays(daysPast);
+
+                var day = new BuildTimeHistory.Models.DailyBuildHistory()
+                {
+                    Date = currentDay
+                };
+
+                for (int j = 0; j < numBuildsToSimulate; j++)
+                {
+                    var build = new BuildHistoryItem()
+                    {
+                        RecordDate = currentDay,
+                        Status = RandomStatus(),
+                        BuildTime = RandomBuildTime()
+                    };
+
+                    day.BuildHistory.Add(build);
+                }
+
+                solutionHistory.DailyBuildHistory.Add(day);
+            }
+
+            service.Save();
+        }
+
+        private BuildCompletionStatus RandomStatus()
+        {
+            var value = _random.Next(1, 3);
+            return (BuildCompletionStatus)value;
+        }
+
+        private double RandomBuildTime()
+        {
+            var value = _random.Next(2000, 600000);
+            return Convert.ToDouble(value);
+        }
+    }
+}

--- a/src/SolutionBuildTimeHistory.Test/Properties/AssemblyInfo.cs
+++ b/src/SolutionBuildTimeHistory.Test/Properties/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("SolutionBuildTimeHistory.Test")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("SolutionBuildTimeHistory.Test")]
+[assembly: AssemblyCopyright("Copyright ©  2024")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("0189ae3b-4b8e-4dd9-87e5-3f2ff301f7b0")]
+
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/SolutionBuildTimeHistory.Test/SolutionBuildTimeHistory.Test.csproj
+++ b/src/SolutionBuildTimeHistory.Test/SolutionBuildTimeHistory.Test.csproj
@@ -1,0 +1,75 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\MSTest.TestAdapter.2.2.10\build\net46\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.2.2.10\build\net46\MSTest.TestAdapter.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{0189AE3B-4B8E-4DD9-87E5-3F2FF301F7B0}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>SolutionBuildTimeHistory.Test</RootNamespace>
+    <AssemblyName>SolutionBuildTimeHistory.Test</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.2.2.10\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.2.2.10\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="BuildHistoryServiceTest.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\BuildTimeHistory\BuildTimeHistory.csproj">
+      <Project>{ebb11b94-8ed3-4cc5-8b46-b3a6b6ea2e6e}</Project>
+      <Name>BuildTimeHistory</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.2.10\build\net46\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.2.10\build\net46\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.2.10\build\net46\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.2.10\build\net46\MSTest.TestAdapter.targets'))" />
+  </Target>
+  <Import Project="..\packages\MSTest.TestAdapter.2.2.10\build\net46\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.2.2.10\build\net46\MSTest.TestAdapter.targets')" />
+</Project>

--- a/src/SolutionBuildTimeHistory.Test/SolutionBuildTimeHistory.Test.csproj
+++ b/src/SolutionBuildTimeHistory.Test/SolutionBuildTimeHistory.Test.csproj
@@ -46,6 +46,9 @@
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.2.2.10\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>

--- a/src/SolutionBuildTimeHistory.Test/packages.config
+++ b/src/SolutionBuildTimeHistory.Test/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MSTest.TestAdapter" version="2.2.10" targetFramework="net472" />
+  <package id="MSTest.TestFramework" version="2.2.10" targetFramework="net472" />
+</packages>

--- a/src/SolutionBuildTimeHistory.Test/packages.config
+++ b/src/SolutionBuildTimeHistory.Test/packages.config
@@ -2,4 +2,5 @@
 <packages>
   <package id="MSTest.TestAdapter" version="2.2.10" targetFramework="net472" />
   <package id="MSTest.TestFramework" version="2.2.10" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
init Unit Tests
Refactored build history tracking by replacing `HistoryRecord` with new `DailyBuildHistory` and `BuildHistoryItem` classes. Removed sponsorship-related code and files (`SponsorDetector.cs` and `SponsorRequestHelper.cs`). Updated project files and added new enums and models. Incremented version to 1.3.
Fixed: output of Build summary
Fixed: GetTodaysRecord creating a new DailyBuildHistory item if no history existed prior
Finialized: Unit Tests
